### PR TITLE
feat: add pull request creation prompt after merge with main

### DIFF
--- a/dist/commands/mergeWithMain.js
+++ b/dist/commands/mergeWithMain.js
@@ -111,4 +111,26 @@ export async function mergeWithMain() {
     // Push updated feature branch
     await git.push('origin', currentBranch);
     console.log('Feature branch pushed to remote.');
+    const { shouldPR } = await inquirer.prompt([
+        {
+            type: 'confirm',
+            name: 'shouldPR',
+            message: 'Do you want to create a pull request for this branch?',
+            default: true,
+        }
+    ]);
+    if (shouldPR) {
+        // Create PR using GitHub CLI
+        const { exec } = await import('child_process');
+        const util = await import('util');
+        const execAsync = util.promisify(exec);
+        try {
+            const cmd = `gh pr create --base main --head ${currentBranch}`;
+            await execAsync(cmd);
+            console.log('Pull request created!');
+        }
+        catch (err) {
+            console.error('Failed to create pull request:', err);
+        }
+    }
 }

--- a/src/commands/mergeWithMain.ts
+++ b/src/commands/mergeWithMain.ts
@@ -125,4 +125,28 @@ export async function mergeWithMain(): Promise<void> {
   // Push updated feature branch
   await git.push('origin', currentBranch);
   console.log('Feature branch pushed to remote.');
+
+  const { shouldPR } = await inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'shouldPR',
+      message: 'Do you want to create a pull request for this branch?',
+      default: true,
+    }
+  ]);
+
+  if (shouldPR) {
+    // Create PR using GitHub CLI
+    const { exec } = await import('child_process');
+    const util = await import('util');
+    const execAsync = util.promisify(exec);
+  
+    try {
+      const cmd = `gh pr create --base main --head ${currentBranch}`;
+      await execAsync(cmd);
+      console.log('Pull request created!');
+    } catch (err) {
+      console.error('Failed to create pull request:', err);
+    }
+  }
 }


### PR DESCRIPTION
Adds a prompt asking the user if they want to create a pull request after merging a feature branch with the main branch. If the user confirms, it uses the GitHub CLI to automatically create the pull request, streamlining the development workflow.